### PR TITLE
Added a Dockerfile FROM ubuntu:18.04 and instructions in addToREADME.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:20.04 as builder
+FROM ubuntu:18.04 as builder
+# ubuntu:20.04 does not include libffi.so.6, but the version of yosys in the 
+# Quicklogic Symbiflow_v1.1.1.gz.run installer needs libffi.so.6, so use 18.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
@@ -6,7 +8,8 @@ ENV TZ=America/Los_Angeles
 RUN apt-get update && apt-get install -y \
     libcanberra-gtk-module \
     wget \
-    xz-utils
+    xz-utils && \
+    rm -rf /var/lib/apt/lists/*
 
 # make /bin/sh symlink to bash instead of dash:
 RUN echo "dash dash/sh boolean false" | debconf-set-selections
@@ -16,8 +19,8 @@ ENV INSTALL_DIR="/opt/symbiflow/eos-s3"
 RUN wget https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain/releases/download/v1.1.0/Symbiflow_v1.1.0.gz.run
 RUN chmod 755 Symbiflow_v1.1.0.gz.run
 RUN ./Symbiflow_v1.1.0.gz.run
+RUN rm Symbiflow_v1.1.0.gz.run
 
 ENV PATH="${INSTALL_DIR}/install/bin:${INSTALL_DIR}/install/bin/python:$PATH"
-
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu:18.04 as builder
-# ubuntu:20.04 does not include libffi.so.6, but the version of yosys in the 
-# Quicklogic Symbiflow_v1.1.1.gz.run installer needs libffi.so.6, so use 18.04
+FROM ubuntu:20.04 as builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN echo "dash dash/sh boolean false" | debconf-set-selections
 RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
 
 ENV INSTALL_DIR="/opt/symbiflow/eos-s3"
-RUN wget https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain/releases/download/v1.1.0/Symbiflow_v1.1.0.gz.run
+RUN wget https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain/releases/download/v1.1.0_Beta/Symbiflow_v1.1.0.gz.run
 RUN chmod 755 Symbiflow_v1.1.0.gz.run
 RUN ./Symbiflow_v1.1.0.gz.run
 RUN rm Symbiflow_v1.1.0.gz.run

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:20.04 as builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Los_Angeles
+
+RUN apt-get update && apt-get install -y \
+    libcanberra-gtk-module \
+    wget \
+    xz-utils
+
+# make /bin/sh symlink to bash instead of dash:
+RUN echo "dash dash/sh boolean false" | debconf-set-selections
+RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+
+ENV INSTALL_DIR="/opt/symbiflow/eos-s3"
+RUN wget https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain/releases/download/v1.1.0/Symbiflow_v1.1.0.gz.run
+RUN chmod 755 Symbiflow_v1.1.0.gz.run
+RUN ./Symbiflow_v1.1.0.gz.run
+
+ENV PATH="${INSTALL_DIR}/install/bin:${INSTALL_DIR}/install/bin/python:$PATH"
+
+
+

--- a/addToREADME.md
+++ b/addToREADME.md
@@ -1,0 +1,21 @@
+# dockerfile-symbiflow-ql
+A Dockerfile that builds a symbiflow container including iverilog, yosys, vtr, and
+gtkwave targeting Quicklogic FPGAs.  See the Quicklogic repo for more info on how 
+to use this.
+
+https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain
+
+You can build and tag the symbiflow-ql container with
+docker build . -t symbiflow-ql
+
+In order to view the gtkwave program, the easiest (but not the safest) thing 
+to do is allow x connections:
+xhost +
+
+docker run -it -e DISPLAY=$DISPLAY -v "/tmp/.X11-unix:/tmp/.X11-unix" symbiflow-ql bash
+
+When you are finished, it would be wise to disallow x connections:
+xhost -
+
+One resource I found for running GUI programs under Docker:
+http://wiki.ros.org/docker/Tutorials/GUI


### PR DESCRIPTION
Added a Dockerfile and instructions on building a Docker image and running it.  The version of yosys in the installer requires libffi.so.6 but ubuntu 20.04 doesn't include that, so this Dockerfile starts from ubuntu 18.04.