### PR TITLE
Dockerfile to create a container that builds from source code

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ dockerfile-build-src ]
+  pull_request:
+    branches: [ dockerfile-build-src ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag symbiflow-ql-slim-buster:$(date +%s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,102 @@
-FROM ubuntu:20.04 as builder
+ARG IMAGE="python:3-slim-buster"
 
-ARG DEBIAN_FRONTEND=noninteractive
-ENV TZ=America/Los_Angeles
+#---
+# Place anything that is common to both the build and execution environment in base 
+#
+FROM $IMAGE AS base
 
-RUN apt-get update && apt-get install -y \
-    libcanberra-gtk-module \
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    ca-certificates \
+    clang \
+    cmake \
+    curl \
+    git \
+    libffi-dev \
+    libreadline-dev \
+    tcl-dev \
+    graphviz \
     wget \
-    xz-utils && \
-    rm -rf /var/lib/apt/lists/*
-
-# make /bin/sh symlink to bash instead of dash:
-RUN echo "dash dash/sh boolean false" | debconf-set-selections
-RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+    xdot \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && update-ca-certificates \
+ && rm -rf /var/lib/apt/lists
 
 ENV INSTALL_DIR="/opt/symbiflow/eos-s3"
-RUN wget https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain/releases/download/v1.1.0/Symbiflow_v1.1.0.gz.run
-RUN chmod 755 Symbiflow_v1.1.0.gz.run
-RUN ./Symbiflow_v1.1.0.gz.run
-RUN rm Symbiflow_v1.1.0.gz.run
+ENV PATH="$INSTALL_DIR/install/bin:$INSTALL_DIR/install/bin/python:$PATH"
+ENV YOSYS=${INSTALL_DIR}/install/bin/yosys
 
-ENV PATH="${INSTALL_DIR}/install/bin:${INSTALL_DIR}/install/bin/python:$PATH"
+#---
 
+FROM base AS build
+
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    bison \
+    build-essential \
+    flex \
+    gawk \
+    git \
+    iverilog \
+    pkg-config
+
+#Checkout *yosys* repository (https://github.com/QuickLogic-Corp/yosys.git), branch: **quicklogic-rebased**. 
+RUN git clone https://github.com/QuickLogic-Corp/yosys.git -b quicklogic-rebased quicklogic-yosys
+RUN cd quicklogic-yosys
+WORKDIR /quicklogic-yosys
+RUN make config-gcc
+RUN make install PREFIX=${INSTALL_DIR}/install
+RUN cd -
+
+#Checkout *yosys-symbiflow-plugins* (https://github.com/QuickLogic-Corp/yosys-symbiflow-plugins), branch: **ql-ios**.
+WORKDIR /
+RUN git clone https://github.com/QuickLogic-Corp/yosys-symbiflow-plugins -b ql-ios
+RUN cd yosys-symbiflow-plugins
+WORKDIR /yosys-symbiflow-plugins
+# export PATH='specify Yosys installation path as specified in PREFIX in previous step':$PATH
+RUN make
+RUN make install
+RUN cd -
+
+#Checkout *vpr* repository (https://github.com/QuickLogic-Corp/vtr-verilog-to-routing.git), branch: **blackbox_timing**.
+WORKDIR /
+RUN git clone https://github.com/QuickLogic-Corp/vtr-verilog-to-routing -b blackbox_timing
+RUN cd vtr-verilog-to-routing
+WORKDIR /vtr-verilog-to-routing
+RUN make
+
+#Checkout *symbiflow-arch-defs* repository (https://github.com/QuickLogic-Corp/symbiflow-arch-defs.git), branch: **quicklogic-upstream-rebase**. 
+WORKDIR /
+RUN git clone https://github.com/QuickLogic-Corp/symbiflow-arch-defs.git -b quicklogic-upstream-rebase
+RUN cd symbiflow-arch-defs
+WORKDIR /symbiflow-arch-defs
+
+RUN make env
+RUN cd build
+RUN make all_conda
+RUN cd -
+RUN make
+
+#---
+
+FROM base
+
+COPY --from=build /opt/symbiflow/eos-s3 /opt/symbiflow/eos-s3/
+COPY --from=build /symbiflow-arch-defs /symbiflow-arch-defs/
+COPY --from=build /yosys-symbiflow-plugins /yosys-symbiflow-plugins/
+
+
+# Build the container with something like:
+# docker build . -t symbiflow-ql-slim-buster
+
+# Run bash in the container interactively with something like:
+# docker run -it symbiflow-ql-slim-buster bash
+
+# cd /symbiflow-arch-defs/build/quicklogic
+# The following command doesn't work, but may be extraneous
+# make file_build_quicklogic_techmap_cells_sim.v
+
+# Run any test case in the container running bash interactively.  For example, follow these steps to run a test case:
+# cd /symbiflow-arch-defs/build/quicklogic/pp3/tests/quicklogic_testsuite/bin2seven
+# make bin2seven-ql-chandalar_fasm
 

--- a/Dockerfile.use-installer
+++ b/Dockerfile.use-installer
@@ -1,0 +1,24 @@
+FROM ubuntu:20.04 as builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Los_Angeles
+
+RUN apt-get update && apt-get install -y \
+    libcanberra-gtk-module \
+    wget \
+    xz-utils && \
+    rm -rf /var/lib/apt/lists/*
+
+# make /bin/sh symlink to bash instead of dash:
+RUN echo "dash dash/sh boolean false" | debconf-set-selections
+RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+
+ENV INSTALL_DIR="/opt/symbiflow/eos-s3"
+RUN wget https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain/releases/download/v1.1.0/Symbiflow_v1.1.0.gz.run
+RUN chmod 755 Symbiflow_v1.1.0.gz.run
+RUN ./Symbiflow_v1.1.0.gz.run
+RUN rm Symbiflow_v1.1.0.gz.run
+
+ENV PATH="${INSTALL_DIR}/install/bin:${INSTALL_DIR}/install/bin/python:$PATH"
+
+

--- a/addToREADME.md
+++ b/addToREADME.md
@@ -1,4 +1,19 @@
-# dockerfile-symbiflow-ql
+# Dockerfile builds the quicklogic-fpga-toolchain from source, as described in
+#   2) Compile from source code and run example 
+# of the instructions here:
+https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain
+
+# Build and tag the container with something like:
+# docker build . -t symbiflow-ql-slim-buster
+
+# Run bash in the container interactively with something like:
+# docker run -it symbiflow-ql-slim-buster bash
+
+
+# The old Dockerfile that built a container from Quicklogic's released installer
+# has been renamed to Dockerfile.use-installer
+# Below are the Instructions on how to build a container from it.
+# dockerfile-symbiflow-ql/Dockerfile.use-installer
 A Dockerfile that builds a symbiflow container including iverilog, yosys, vtr, and
 gtkwave targeting Quicklogic FPGAs.  See the Quicklogic repo for more info on how 
 to use this.
@@ -6,7 +21,7 @@ to use this.
 https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain
 
 You can build and tag the symbiflow-ql container with
-docker build . -t symbiflow-ql
+docker build . -f Dockerfile.use-installer -t symbiflow-ql
 
 In order to view the gtkwave program, the easiest (but not the safest) thing 
 to do is allow x connections:
@@ -19,3 +34,13 @@ xhost -
 
 One resource I found for running GUI programs under Docker:
 http://wiki.ros.org/docker/Tutorials/GUI
+
+# TODO
+# The directory structure of these two containers should match.
+#
+# The Dockerfile that builds the container and builds the tools
+# from source should also package up an installer that matches Quicklogic's installer
+#
+# Use github actions to build the container, and under it the quicklogic tools
+# and installer, run tests in the container, and run tests in a container built
+# from the installer.


### PR DESCRIPTION
Modified Dockerfile to create a container and build quicklogic-fpga-toolchain from source as documented in README.md.  Renamed old Dockerfile that uses the installer to create a lighter weight container for running quicklogic-fpga-toolchain to Dockerfile.use-installer.