### PR TITLE
Proposal for effective docker

### DIFF
--- a/Dockerfile.entrypoint-make
+++ b/Dockerfile.entrypoint-make
@@ -1,0 +1,46 @@
+ARG IMAGE="symbiflow-ql:1.2.0"
+FROM ${IMAGE} as base
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Los_Angeles
+
+RUN apt-get update && apt-get install -y \
+    libusb-1.0-0 \
+    make \
+    udev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN chmod 755 /opt/symbiflow && \
+    chmod 755 /opt/symbiflow/eos-s3 && \
+    chmod -R 755 /opt/symbiflow/eos-s3/conda
+
+FROM base as release-candidate
+
+ARG USER=ic
+ARG UID=1000
+ARG GID=1000
+RUN addgroup --gid ${GID} ${USER}
+RUN adduser --uid ${UID} --gid ${GID} --gecos "" --disabled-password --shell /bin/bash ${USER} 
+#RUN usermod -a -G plugdev ${USER}
+# COPY 99-fomu.rules /etc/udev/rules.d/99-fomu.rules
+USER ${USER}
+WORKDIR /home/${USER}
+
+ENTRYPOINT [ "make" ]
+
+FROM release-candidate as symbiflow-ql-make
+
+# Below are some example commands to build and run a docker container
+#
+# docker build -f Dockerfile.entrypoint-make . -t symbiflow-ql-make 
+# 
+# In a directory containing a Makefile that runs symbiflow tools:
+# docker run -v $(pwd):/home/ic symbiflow-ql-make
+#
+# The above will execute make within the running container.  Any
+# tools called by the makefile will run within the container.
+#
+# You can run the container with an optional command, which it 
+# passes to make.  For instance to run 'make clean' in the container:
+#
+# # docker run -v $(pwd):/home/ic symbiflow-ql-make clean

--- a/Dockerfile.user
+++ b/Dockerfile.user
@@ -6,6 +6,7 @@ ENV TZ=America/Los_Angeles
 
 RUN apt-get update && apt-get install -y \
     libusb-1.0-0 \
+    make \
     udev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.user
+++ b/Dockerfile.user
@@ -1,0 +1,33 @@
+ARG IMAGE="symbiflow-ql:1.2.0"
+FROM ${IMAGE} as base
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Los_Angeles
+
+RUN apt-get update && apt-get install -y \
+    libusb-1.0-0 \
+    udev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN chmod 755 /opt/symbiflow && \
+    chmod 755 /opt/symbiflow/eos-s3 && \
+    chmod -R 755 /opt/symbiflow/eos-s3/conda
+
+FROM base as release-candidate
+
+ARG USER=ic
+ARG UID=1000
+ARG GID=1000
+RUN addgroup --gid ${GID} ${USER}
+# RUN useradd -m -u $UID -g $GID -o -s /bin/bash $USER
+RUN adduser --uid ${UID} --gid ${GID} --gecos "" --disabled-password --shell /bin/bash ${USER} 
+# RUN groupadd plugdev # error - already exists
+RUN usermod -a -G plugdev ${USER}
+# COPY 99-fomu.rules /etc/udev/rules.d/99-fomu.rules
+# RUN udevadm control --reload-rules
+# RUN udevadm trigger
+USER ${USER}
+WORKDIR /home/${USER}
+
+FROM release-candidate as symbiflow-ql-user
+

--- a/more_effective_docker/example_fpga_designs/fpga_helloworldhw/Makefile
+++ b/more_effective_docker/example_fpga_designs/fpga_helloworldhw/Makefile
@@ -1,0 +1,77 @@
+SHELL=/bin/bash
+CONDATOOL=/opt/symbiflow/eos-s3/conda
+TOP := helloworldfpga
+VERILOG := helloworldfpga.v  
+PARTNAME := PU64
+DEVICE  := ql-eos-s3_wlcsp
+PCF := quickfeather.pcf
+SDC := helloworldfpga_dummy.sdc
+BUILDDIR := build
+
+ 
+.PHONY: all
+all: ${BUILDDIR}/${TOP}.bit
+
+${BUILDDIR}:
+	mkdir ${BUILDDIR}
+
+${BUILDDIR}/${TOP}.eblif: ${VERILOG} ${BUILDDIR}
+	source ${CONDATOOL}/etc/profile.d/conda.sh && conda activate && \
+	cd ${BUILDDIR} && synth -t ${TOP} -v ../${VERILOG} -d ${DEVICE} -p ../${PCF} -P ${PART} 2>&1 > ${TOP}.log && \
+	conda deactivate
+
+${BUILDDIR}/${TOP}.net: ${BUILDDIR}/${TOP}.eblif
+	source ${CONDATOOL}/etc/profile.d/conda.sh && conda activate && \
+	cd ${BUILDDIR} && pack -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 >> ${TOP}.log && \
+	conda deactivate
+
+${BUILDDIR}/${TOP}.place: ${BUILDDIR}/${TOP}.net
+	source ${CONDATOOL}/etc/profile.d/conda.sh && conda activate && \
+	cd ${BUILDDIR} && place -e ${TOP}.eblif -d ${DEVICE} -p ../${PCF} -n ${TOP}.net -P ${PARTNAME} -s ${SDC} 2>&1 >> ${TOP}.log && \
+	conda deactivate
+
+${BUILDDIR}/${TOP}.route: ${BUILDDIR}/${TOP}.place
+	source ${CONDATOOL}/etc/profile.d/conda.sh && conda activate && \
+	cd ${BUILDDIR} && route -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 >> ${TOP}.log && \
+	conda deactivate
+
+${BUILDDIR}/${TOP}.fasm: ${BUILDDIR}/${TOP}.route
+	source ${CONDATOOL}/etc/profile.d/conda.sh && conda activate && \
+	cd ${BUILDDIR} && write_fasm -e ${TOP}.eblif -d ${DEVICE} 2>&1 >> ${TOP}.log && \
+	conda deactivate
+
+${BUILDDIR}/${TOP}.bit: ${BUILDDIR}/${TOP}.fasm
+	source ${CONDATOOL}/etc/profile.d/conda.sh && conda activate && \
+	cd ${BUILDDIR} && write_bitstream -d ${DEVICE} -f ${TOP}.fasm -P ${PARTNAME} -b ${TOP}.bit 2>&1 >> ${TOP}.log && \
+	conda deactivate
+
+${BUILDDIR}/${TOP}_bit.h: ${BUILDDIR}/${TOP}.bit
+	source ${CONDATOOL}/etc/profile.d/conda.sh && conda activate && \
+	cd ${BUILDDIR} && write_bitheader -b ${TOP}.bit 2>&1 >> ${TOP}.log && \
+	conda deactivate
+
+${BUILDDIR}/${TOP}.jlink: ${BUILDDIR}/${TOP}.bit
+	source ${CONDATOOL}/etc/profile.d/conda.sh && conda activate && \
+	cd ${BUILDDIR} && write_jlink -f ${TOP}.fasm -P ${PACKAGENAME} -b ${TOP}.bit 2>&1 >> ${TOP}.log && \
+	conda deactivate
+
+${BUILDDIR}/${TOP}_jlink.h: ${BUILDDIR}/${TOP}.jlink
+	source ${CONDATOOL}/etc/profile.d/conda.sh && conda activate && \
+	cd ${BUILDDIR} && write_jlinkheader 2>&1 >> ${TOP}.log && \
+	conda deactivate
+
+${BUILDDIR}/${TOP}.post_v: ${BUILDDIR}/${TOP}.bit
+	source ${CONDATOOL}/etc/profile.d/conda.sh && conda activate && \
+	cd ${BUILDDIR} && \
+	write_fasm2bels -e ${TOP}.eblif -d ${DEVICE} -p ../${PCF} -n ${TOP}.net -P ${PARTNAME} 2>&1 >> ${TOP}.log && \
+	analysis -e ${TOP}.eblif -d ${DEVICE} -s ${SDC} 2>&1 >> ${TOP}.log && \
+	conda deactivate
+
+.PHONY: clean
+clean:
+	rm -rf ${BUILDDIR}
+
+
+
+
+


### PR DESCRIPTION
I have created a couple of Dockerfile examples.  The first is Dockerfile.user.  

Currently, it starts FROM symbiflow-ql:1.2.0
It installs make (not absolutely needed, but the version that is already there 
requires conda to be activated, which you may want to do within a Makefile.)
It fixes the permissions on the symbiflow directories via 'chmod 755'
Then it adds a user.
You can run symbiflow tools interactively within this container.

The second, Dockerfile.entrypoint-make is almost identical, but adds
an ENTRYPOINT [ "make" ] 
If you run this container, it runs make on the Makefile in the current directory.
There are come comments/instructions at the bottom of Dockerfile.entrypoint-make
I added a Makefile as an example to show how this works.  I think it is a little simpler
than the Makefile.symbiflow example overall, and it doesn't require any external shell
scripts.  However, I would like it to be simpler still.  Notice that each build target requires activating conda and deactivating conda wrapped around the build command.  I think it may be possible to chain entrypoints such that conda is activated before make runs, which should eliminate this minor complication of the Makefile.   For easy reference, the instructions from the Dockerfile.entrypoint-make are reproduced here:

# Below are some example commands to build and run a docker container
#
# docker build -f Dockerfile.entrypoint-make . -t symbiflow-ql-make 
# 
# In a directory containing a Makefile that runs symbiflow tools:
# docker run -v $(pwd):/home/ic symbiflow-ql-make
#
# The above will execute make within the running container.  Any
# tools called by the makefile will run within the container.
#
# You can run the container with an optional command, which it 
# passes to make.  For instance to run 'make clean' in the container:
#
# # docker run -v $(pwd):/home/ic symbiflow-ql-make clean

Doug