### PR TITLE
Dockerfile use installer inject version tag

### DIFF
--- a/.github/workflows/docker-publish-tagged.yml
+++ b/.github/workflows/docker-publish-tagged.yml
@@ -33,6 +33,9 @@ jobs:
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
   
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
   

--- a/.github/workflows/docker-publish-tagged.yml
+++ b/.github/workflows/docker-publish-tagged.yml
@@ -17,7 +17,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build --build-arg GITHUB_WORKSPACE=$GITHUB_WORKSPACE . --file Dockerfile.use-installer --tag $IMAGE_NAME
+        run:  |
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          docker build --build-arg TAG=$VERSION . --file Dockerfile.use-installer --tag $IMAGE_NAME
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
@@ -28,9 +32,6 @@ jobs:
   
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-  
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
   
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')

--- a/Dockerfile.use-installer
+++ b/Dockerfile.use-installer
@@ -15,7 +15,7 @@ RUN echo "dash dash/sh boolean false" | debconf-set-selections
 RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
 
 # add ARGs so that these can be passed in while doing a docker build, the following will be default values
-ARG TAG=v1.3.0
+ARG TAG=v0.0.0
 ENV INSTALL_DIR="/opt/symbiflow/eos-s3"
 # Appending all of these commands (mostly the chmod 755 commands) saved about 1.9 GB in image size
 RUN wget https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain/releases/download/${TAG}/Symbiflow_${TAG}.gz.run && \


### PR DESCRIPTION
This pull request eliminates the issue where a package may be built with an older installer if someone forgot to modify the version tag in the Dockerfile before tagging the version and pushing it.  We had an issue where the 1.3.0 package was built from the 1.2.0 installer because the Dockerfile.use-installer file had a default version of 1.2.0.
 
Rather than changing the Dockerfile.use-installer file to the currently published version every time a new tagged version is released, set the default to a non-existent installer (v0.0.0) and inject the version automatically through the --build-arg TAG by getting it from the tagged version that is being pushed.  This has been tested in the Thirsty2/quicklogic-fpga-toolchain repo, and works well as long as the tagged versions pushed to github are of the form vX.Y.Z where X, Y, and Z are integers, and v is the character 'v'.  The installer has to exist and be downloadable through wget at a path produced automatically from this version.  The v1.2.0 and v1.3.0 installers do exist in locations that adhere to the assumptions in this pull request.

